### PR TITLE
Explictly use "rgb" as color space in color.mix

### DIFF
--- a/template.typ
+++ b/template.typ
@@ -23,7 +23,7 @@
   // Set colors
   let primary-color = rgb(main_color) // alpha = 100%
   // change alpha of primary color
-  let secondary-color = color.mix(color.rgb(100%, 100%, 100%, alpha), primary-color)
+  let secondary-color = color.mix(color.rgb(100%, 100%, 100%, alpha), primary-color, space:rgb)
 
   show "highlight" : it => text(fill: primary-color)[#it]
 


### PR DESCRIPTION
The default color space of color.mix is oklab, but we want to use rgb here.

Ref:
https://typst.app/docs/reference/visualize/color/#definitions-mix